### PR TITLE
Fix: After a filtered person search, there is no dedicated way to restore the full person list other than running list again

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -183,6 +183,8 @@ Format: `list`
 #### Locating persons by multiple fields: `find`
 
 Finds persons whose fields (name, phone, email, tasks, projects) match the given keywords.
+> [!IMPORTANT]
+> This command will update to show the filtered list of persons that match the search criteria. To restore the original list of all persons, use the `list` command.
 
 Format: `find [-n NAME_KEYWORDS] [-p PHONE_KEYWORDS] [-e EMAIL_KEYWORDS] [-d TASK_KEYWORDS] [-l PROJECT_KEYWORDS]`
 


### PR DESCRIPTION
Closes #249 
Closes #235 